### PR TITLE
added java option for slow startup recommended by Atlassian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN set -x \
     && chown -R daemon:daemon "${BITBUCKET_INSTALL}/work" \
     && ln --symbolic          "/usr/lib/x86_64-linux-gnu/libtcnative-1.so" "${BITBUCKET_INSTALL}/lib/native/libtcnative-1.so" \
     && sed --in-place         's/^# umask 0027$/umask 0027/g' "${BITBUCKET_INSTALL}/bin/setenv.sh" \
+    && sed --in-place         's/JVM_SUPPORT_RECOMMENDED_ARGS=""/JVM_SUPPORT_RECOMMENDED_ARGS="-Djava.security.egd=file:\/dev\/.\/urandom"/g' "${BITBUCKET_INSTALL}/bin/setenv.sh" \
     && xmlstarlet             ed --inplace \
         --delete              "Server/Service/Engine/Host/@xmlValidation" \
         --delete              "Server/Service/Engine/Host/@xmlNamespaceAware" \


### PR DESCRIPTION
I had issues getting the Bitbucket container to startup on a Google Compute Engine/Ubuntu 16.04  instance.  The container would hang when starting because the SSH plugin gets stuck when trying to create a secure random number.

Adding this change [recommended](https://confluence.atlassian.com/bitbucketserverkb/required-plugin-com-atlassian-stash-ssh-plugin-has-failed-to-start-is-displayed-when-accessing-the-bitbucket-server-web-interface-779171299.html) by Atlassian fixed the issue.