### PR TITLE
Crowd sso support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,27 @@
-FROM openjdk:8
+FROM openjdk:8-alpine
 
 # Setup useful environment variables
-ENV BITBUCKET_HOME     /var/atlassian/bitbucket
-ENV BITBUCKET_INSTALL  /opt/atlassian/bitbucket
-ENV BITBUCKET_VERSION  4.14.4
+ENV BITBUCKET_HOME          /var/atlassian/bitbucket
+ENV BITBUCKET_INSTALL       /opt/atlassian/bitbucket
+ENV BITBUCKET_VERSION       5.14.1
+ENV MYSQL_CONNECTOR_VERSION 5.1.47
 
 # Install Atlassian Bitbucket and helper tools and setup initial home
 # directory structure.
 RUN set -x \
-    && echo "deb http://ftp.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list \
-    && apt-get update --quiet \
-    && apt-get install --quiet --yes --no-install-recommends git-core xmlstarlet \
-    && apt-get install --quiet --yes --no-install-recommends -t jessie-backports libtcnative-1 \
-    && apt-get clean \
-    && mkdir -p               "${BITBUCKET_HOME}/lib" \
+    && apk --no-cache add git curl bash ttf-dejavu libc6-compat \
+    && mkdir -p               "${BITBUCKET_HOME}/shared" \
+    && touch                  "${BITBUCKET_HOME}/shared/bitbucket.properties" \
     && chmod -R 700           "${BITBUCKET_HOME}" \
     && chown -R daemon:daemon "${BITBUCKET_HOME}" \
     && mkdir -p               "${BITBUCKET_INSTALL}" \
     && curl -Ls               "https://www.atlassian.com/software/stash/downloads/binary/atlassian-bitbucket-${BITBUCKET_VERSION}.tar.gz" | tar -zx --directory  "${BITBUCKET_INSTALL}" --strip-components=1 --no-same-owner \
-    && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz" | tar -xz --directory "${BITBUCKET_INSTALL}/lib" --strip-components=1 --no-same-owner "mysql-connector-java-5.1.38/mysql-connector-java-5.1.38-bin.jar" \
-    && chmod -R 700           "${BITBUCKET_INSTALL}/conf" \
-    && chmod -R 700           "${BITBUCKET_INSTALL}/logs" \
-    && chmod -R 700           "${BITBUCKET_INSTALL}/temp" \
-    && chmod -R 700           "${BITBUCKET_INSTALL}/work" \
-    && chown -R daemon:daemon "${BITBUCKET_INSTALL}/conf" \
-    && chown -R daemon:daemon "${BITBUCKET_INSTALL}/logs" \
-    && chown -R daemon:daemon "${BITBUCKET_INSTALL}/temp" \
-    && chown -R daemon:daemon "${BITBUCKET_INSTALL}/work" \
-    && ln --symbolic          "/usr/lib/x86_64-linux-gnu/libtcnative-1.so" "${BITBUCKET_INSTALL}/lib/native/libtcnative-1.so" \
-    && sed --in-place         's/^# umask 0027$/umask 0027/g' "${BITBUCKET_INSTALL}/bin/setenv.sh" \
-    && xmlstarlet             ed --inplace \
-        --delete              "Server/Service/Engine/Host/@xmlValidation" \
-        --delete              "Server/Service/Engine/Host/@xmlNamespaceAware" \
-                              "${BITBUCKET_INSTALL}/conf/server.xml" \
-    && touch -d "@0"          "${BITBUCKET_INSTALL}/conf/server.xml"
+    && curl -Ls                "https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}.tar.gz" | tar -xz --directory "${BITBUCKET_INSTALL}/app/WEB-INF/lib" --strip-components=1 --no-same-owner "mysql-connector-java-${MYSQL_CONNECTOR_VERSION}/mysql-connector-java-${MYSQL_CONNECTOR_VERSION}-bin.jar" 
 
 # Use the default unprivileged account. This could be considered bad practice
 # on systems where multiple processes end up being executed by 'daemon' but
 # here we only ever run one process anyway.
-# USER daemon:daemon
+USER daemon:daemon
 
 # Expose default HTTP and SSH ports.
 EXPOSE 7990 7999
@@ -55,4 +38,4 @@ COPY "docker-entrypoint.sh" "/"
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 # Run Atlassian Bitbucket as a foreground process by default.
-CMD ["/opt/atlassian/bitbucket/bin/catalina.sh", "run"]
+CMD ["/opt/atlassian/bitbucket/bin/start-bitbucket.sh", "-fg"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV MYSQL_CONNECTOR_VERSION 5.1.47
 # Install Atlassian Bitbucket and helper tools and setup initial home
 # directory structure.
 RUN set -x \
-    && apk --no-cache add git curl bash ttf-dejavu libc6-compat \
+    && apk --no-cache add git curl bash ttf-dejavu libc6-compat procps \
     && mkdir -p               "${BITBUCKET_HOME}/shared" \
     && touch                  "${BITBUCKET_HOME}/shared/bitbucket.properties" \
     && chmod -R 700           "${BITBUCKET_HOME}" \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ docker run --detach --publish 7990:7990 cptactionhank/atlassian-bitbucket:latest
 
 Then simply navigate your preferred browser to `http://[dockerhost]:7990` and finish the configuration.
 
+## Configuration
+
+You can configure a small set of things by supplying the following environment variables
+
+| Environment Variable   | Description |
+| ---------------------- | ----------- |
+| X_PATH                 | Sets the Tomcat connectors `path` attribute |
+| X_CROWD_SSO            | Set to `true` to enable SSO via Atlassian Crowd
+
+## How to enable SSO via Crowd
+
+Setting X_CROWD_SSO to `true` will enable Crowd SSO in your bitbucket.properties.
+You will have to put your `crowd-properties.conf` to `${BITBUCKET_HOME}/shared` and set up the user directory in Bitbucket.
+
+See the [official Documentation](https://confluence.atlassian.com/bitbucketserver/connecting-bitbucket-server-to-crowd-776640399.html) for more information.
+
 ## Contributions
 
 This image has been created with the best intentions and an expert understanding of docker, but it should not be expected to be flawless. Should you be in the position to do so, I request that you help support this repository with best-practices and other additions.


### PR DESCRIPTION
First of all, this fixes #8 . I've reworked pretty much of Dockerfile and docker-entrypoint.sh due to the changes between Bitbucket 4 and 5.
Also, SSO login via Crowd is now possible.

[upgraded] Bitbucket to 5.14.1
[changed] base image is now openjdk:8-alpine
[added] options to configure context path and Crowd SSO
[updated] README.md